### PR TITLE
Ugly but functional multiline tokenizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /haberdasher
 dist/
+.vscode/


### PR DESCRIPTION
This seems to both resolve the log duplication and allows for stack-traces/indented multiline logs to be captured as one entry.

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>